### PR TITLE
Allow retry on authentication timed out.

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -160,6 +160,12 @@ namespace EventStore.ClientAPI {
 		/// </summary>
 		public readonly string CompatibilityMode;
 
+		/// <summary>
+		/// If enabled, the client will not skip authentication if the process times out. The maximun retries count is the same as
+		/// ConnectionSettings.MaxRetries.
+		/// </summary>
+		public readonly bool RetryAuthenticationOnTimeout;
+
 		internal ConnectionSettings(ILogger log,
 			bool verboseLogging,
 			int maxQueueSize,
@@ -185,6 +191,7 @@ namespace EventStore.ClientAPI {
 			TimeSpan gossipTimeout,
 			NodePreference nodePreference,
 			string compatibilityMode,
+			bool retryAuthenticationOnTimeout,
 			HttpMessageHandler customHttpMessageHandler) {
 
 			Ensure.NotNull(log, "log");
@@ -230,6 +237,7 @@ namespace EventStore.ClientAPI {
 			GossipTimeout = gossipTimeout;
 			NodePreference = nodePreference;
 			CompatibilityMode = compatibilityMode;
+			RetryAuthenticationOnTimeout = retryAuthenticationOnTimeout;
 			CustomHttpMessageHandler = customHttpMessageHandler;
 		}
 	}

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -41,6 +41,7 @@ namespace EventStore.ClientAPI {
 		private GossipSeed[] _gossipSeeds;
 		private NodePreference _nodePreference = NodePreference.Leader;
 		private string _compatibilityMode = "";
+		private bool _retryAuthenticationOnTimeout;
 		private HttpMessageHandler _customHttpMessageHandler;
 
 		internal ConnectionSettingsBuilder() {
@@ -363,7 +364,7 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Whether to prioritize choosing a read only replica that's alive from the known nodes. 
+		/// Whether to prioritize choosing a read only replica that's alive from the known nodes.
 		/// </summary>
 		/// <returns>A <see cref="ConnectionSettingsBuilder"/> for further configuration.</returns>
 		public ConnectionSettingsBuilder PreferReadOnlyReplica() {
@@ -374,7 +375,7 @@ namespace EventStore.ClientAPI {
 
 		/// <summary>
 		/// Sets the well-known port on which the cluster gossip is taking place.
-		/// 
+		///
 		/// This should be the HTTP port that the nodes are running on. If you cannot use a well-known
 		/// port for this across all nodes, you can instead use gossip seed discovery and set
 		/// the <see cref="EndPoint" /> of some seed nodes instead.
@@ -452,6 +453,16 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
+		/// If enabled, the client will not skip authentication if the process times out. The maximun retries count is the same as
+		/// ConnectionSettings.MaxRetries.
+		/// </summary>
+		/// <returns>A <see cref="ConnectionSettingsBuilder"/> for further configuration.</returns>
+		public ConnectionSettingsBuilder RetryAuthenticationOnTimeout() {
+			_retryAuthenticationOnTimeout = true;
+			return this;
+		}
+
+		/// <summary>
 		/// Convert the mutable <see cref="ConnectionSettingsBuilder"/> object to an immutable
 		/// <see cref="ConnectionSettings"/> object.
 		/// </summary>
@@ -491,6 +502,7 @@ namespace EventStore.ClientAPI {
 				_gossipTimeout,
 				_nodePreference,
 				_compatibilityMode,
+				_retryAuthenticationOnTimeout,
 				_customHttpMessageHandler);
 		}
 	}

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -103,7 +103,7 @@ namespace EventStore.ClientAPI {
 						connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns,
 						connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
 						connectionSettings.GossipPort, connectionSettings.GossipTimeout,
-						connectionSettings.NodePreference, connectionSettings.CompatibilityMode, connectionSettings.CustomHttpMessageHandler);
+						connectionSettings.NodePreference, connectionSettings.CompatibilityMode, connectionSettings.RetryAuthenticationOnTimeout, connectionSettings.CustomHttpMessageHandler);
 				}
 
 				if (scheme == "discover") {

--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -50,7 +50,7 @@ namespace EventStore.ClientAPI.Internal {
 
 			_esConnection = esConnection;
 			_settings = settings;
-			
+
 			// NOTE: It can happen the user submitted operations before the connection was available and got postponed
 			// by the operation or subscription manager. This leads the first operation to take time before being
 			// executed. By initializing _lastTimeoutsTimeStamp like this we prevent the first operation from taking a
@@ -278,8 +278,8 @@ namespace EventStore.ClientAPI.Internal {
 
 			if (_settings.DefaultUserCredentials != null) {
 				_connectingPhase = ConnectingPhase.Authentication;
+				_authInfo = new AuthInfo(Guid.NewGuid(), _stopwatch.Elapsed, 0);
 
-				_authInfo = new AuthInfo(Guid.NewGuid(), _stopwatch.Elapsed);
 				var package = _settings.DefaultUserCredentials.AuthToken != null
 					? new TcpPackage(TcpCommand.Authenticate,
 						TcpFlags.Authenticated,
@@ -353,8 +353,31 @@ namespace EventStore.ClientAPI.Internal {
 
 					if (_connectingPhase == ConnectingPhase.Authentication &&
 					    _stopwatch.Elapsed - _authInfo.TimeStamp >= _settings.OperationTimeout) {
-						RaiseAuthenticationFailed("Authentication timed out.");
-						GoToIdentifyState();
+
+						if (!_settings.RetryAuthenticationOnTimeout || (_settings.MaxRetries != -1 && _authInfo.Retries >= _settings.MaxRetries)) {
+							RaiseAuthenticationFailed("Authentication timed out.");
+							GoToIdentifyState();
+						} else {
+							// We resend the authentication package if the authentication phase has failed.
+							_authInfo = new AuthInfo(_authInfo.CorrelationId, _stopwatch.Elapsed, _authInfo.Retries + 1);
+							var max = _settings.MaxRetries == -1 ? "inf" : _settings.MaxRetries.ToString();
+							LogInfo($"Authentication timed out. Retrying... {_authInfo.Retries}/{max}");
+
+							var package = _settings.DefaultUserCredentials.AuthToken != null
+								? new TcpPackage(TcpCommand.Authenticate,
+									TcpFlags.Authenticated,
+									_authInfo.CorrelationId,
+									_settings.DefaultUserCredentials.AuthToken,
+									null)
+								: new TcpPackage(TcpCommand.Authenticate,
+									TcpFlags.Authenticated,
+									_authInfo.CorrelationId,
+									_settings.DefaultUserCredentials.Username,
+									_settings.DefaultUserCredentials.Password,
+									null);
+
+							_connection.EnqueueSend(package);
+						}
 					}
 
 					if (_connectingPhase == ConnectingPhase.Identification &&
@@ -722,10 +745,12 @@ namespace EventStore.ClientAPI.Internal {
 		private struct AuthInfo {
 			public readonly Guid CorrelationId;
 			public readonly TimeSpan TimeStamp;
+			public readonly int Retries;
 
-			public AuthInfo(Guid correlationId, TimeSpan timeStamp) {
+			public AuthInfo(Guid correlationId, TimeSpan timeStamp, int retries) {
 				CorrelationId = correlationId;
 				TimeStamp = timeStamp;
+				Retries = retries;
 			}
 		}
 


### PR DESCRIPTION
~This patch allows the client to restart the connection process from scratch if the authentication process is timed out~ **This patch allows the client to re-issue an authentication request if the authentication process has timed out**. The retry limit is tied to the connection `MaxRetries` setting. If the client goes above that limit, then the workflow resumes to the identification phase. ~We might consider closing the connection for good if it happens though.~

All this new behavior will be gated behind a new setting so it doesn't conflict with the previous connection workflow.