### PR TITLE
Temporarily disable push to github packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,11 @@ jobs:
       with:
         path: packages
         name: nuget-packages
-    - name: Dotnet Push to Github Packages
-      if: github.event_name == 'push'
-      run: |
-        dotnet tool restore
-        find . -name "*.nupkg" | xargs -n1 dotnet tool run gpr -- push --api-key=${{ secrets.github_token }}
+    # - name: Dotnet Push to Github Packages
+    #   if: github.event_name == 'push'
+    #   run: |
+    #     dotnet tool restore
+    #     find . -name "*.nupkg" | xargs -n1 dotnet tool run gpr -- push --api-key=${{ secrets.github_token }}
     - name: Dotnet Push to Nuget.org
       if: github.event_name == 'push' && startsWith(steps.get_version.outputs.branch, 'refs/tags/v')
       run: |


### PR DESCRIPTION
We can't push to github packages at the moment because there are already `EventStore.Client` packages in the `EventStore/EventStore` repo