### PR TITLE
Build against a specific tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest]
         test: [""]
         configuration: [release]
-        docker-tag: ['ci']
+        docker-tag: ['21.2.1-alpha.0.157-alpine']
     runs-on: ${{ matrix.os }}
     name: build-${{ matrix.os }}/${{ matrix.framework }}/EventStore.ClientAPI${{ matrix.test }}
     steps:


### PR DESCRIPTION
`21.2.1-alpha.0.157-alpine` just for now.

Immediate problem is the `ci` has a breaking change for the client and we need to release the client.