### PR TITLE
Allow selection of particular docker image

### DIFF
--- a/test/EventStore.ClientAPI.Tests/GlobalEnvironment.cs
+++ b/test/EventStore.ClientAPI.Tests/GlobalEnvironment.cs
@@ -11,10 +11,12 @@ namespace EventStore.ClientAPI {
 
 		public static bool UseCluster { get; } = false;
 
+		public static string Image => GetEnvironmentVariable(ImageName, ImageDefault);
 		public static string ImageTag => GetEnvironmentVariable(ImageTagName, ImageTagDefault);
 		public static string DbLogFormat => GetEnvironmentVariable(DbLogFormatName, DbLogFormatDefault);
 
 		public static string[] EnvironmentVariables => new[] {
+			$"{ImageName}={Image}",
 			$"{ImageTagName}={ImageTag}",
 			$"{DbLogFormatName}={DbLogFormat}",
 		};
@@ -23,6 +25,8 @@ namespace EventStore.ClientAPI {
 		public static bool IsLogV3 => string.Equals(DbLogFormat, "experimentalV3", StringComparison.OrdinalIgnoreCase);
 
 		static string UseClusterName => "ES_USE_CLUSTER";
+		static string ImageName => "ES_DOCKER_IMAGE";
+		static string ImageDefault => "ghcr.io/eventstore/eventstore"; // old: "docker.pkg.github.com/eventstore/eventstore/eventstore"
 		static string ImageTagName => "ES_DOCKER_TAG";
 		static string ImageTagDefault => "ci"; // e.g. "21.6.0-focal";
 		static string DbLogFormatName => "EVENTSTORE_DB_LOG_FORMAT";

--- a/test/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPISingleNodeFixture.cs
+++ b/test/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPISingleNodeFixture.cs
@@ -28,7 +28,7 @@ namespace EventStore.ClientAPI {
 			// might be useful to make memdb configurable too
 			_eventStore = new Builder()
 				.UseContainer()
-				.UseImage($"ghcr.io/eventstore/eventstore:{GlobalEnvironment.ImageTag}")
+				.UseImage($"{GlobalEnvironment.Image}:{GlobalEnvironment.ImageTag}")
 				.WithName("es-client-dotnet-legacy-test")
 				.WithEnvironment(
 					"EVENTSTORE_DB_LOG_FORMAT=" + GlobalEnvironment.DbLogFormat,

--- a/test/EventStore.ClientAPIAcceptanceTests/docker-compose.yml
+++ b/test/EventStore.ClientAPIAcceptanceTests/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     depends_on:
       - volumes-provisioner
   esdb-node1:
-    image: ghcr.io/eventstore/eventstore:${ES_DOCKER_TAG}
+    image: ${ES_DOCKER_IMAGE}:${ES_DOCKER_TAG}
     env_file:
       - shared.env
     environment:
@@ -52,7 +52,7 @@ services:
       - cert-gen
 
   esdb-node2:
-    image: ghcr.io/eventstore/eventstore:${ES_DOCKER_TAG}
+    image: ${ES_DOCKER_IMAGE}:${ES_DOCKER_TAG}
     env_file:
       - shared.env
     environment:
@@ -77,7 +77,7 @@ services:
       - cert-gen
 
   esdb-node3:
-    image: ghcr.io/eventstore/eventstore:${ES_DOCKER_TAG}
+    image: ${ES_DOCKER_IMAGE}:${ES_DOCKER_TAG}
     env_file:
       - shared.env
     environment:
@@ -102,7 +102,7 @@ services:
       - cert-gen
 
   esdb-node4:
-    image: ghcr.io/eventstore/eventstore:${ES_DOCKER_TAG}
+    image: ${ES_DOCKER_IMAGE}:${ES_DOCKER_TAG}
     env_file:
       - shared.env
     environment:


### PR DESCRIPTION
Prior to this change we could select a tag to run the tests against with the `ES_DOCKER_TAG` env var.
This change adds a way to choose the image as well, with the `ES_DOCKER_IMAGE` env var.