### PR TITLE
Remove extra variable in ConcurrentQueueWrapper.Count

### DIFF
--- a/src/EventStore.ClientAPI/Common/Utils/Threading/ConcurrentQueueWrapper.cs
+++ b/src/EventStore.ClientAPI/Common/Utils/Threading/ConcurrentQueueWrapper.cs
@@ -15,8 +15,7 @@ namespace EventStore.ClientAPI.Common.Utils.Threading {
 
 		public new int Count {
 			get {
-				int curCount = _queueCount;
-				return curCount < 0 ? 0 : curCount;
+				return _queueCount < 0 ? 0 : _queueCount;
 			}
 		}
 


### PR DESCRIPTION
Changed: Remove the extra variable declaration in ConcurrentQueueWrapper.Count