### PR TITLE
Catch exceptions when establishing a TCP connection

### DIFF
--- a/src/EventStore.ClientAPI/Internal/SubscriptionsManager.cs
+++ b/src/EventStore.ClientAPI/Internal/SubscriptionsManager.cs
@@ -89,8 +89,9 @@ namespace EventStore.ClientAPI.Internal {
 		}
 
 		public void CheckTimeoutsAndRetry(TcpPackageConnection connection) {
-			Ensure.NotNull(connection, "connection");
-
+			if (connection is null) {
+				return;
+			}
 			var retrySubscriptions = new List<SubscriptionItem>();
 			var removeSubscriptions = new List<SubscriptionItem>();
 			foreach (var subscription in _activeSubscriptions.Values) {


### PR DESCRIPTION
Set the connection back into connecting mode so that the connection is retried when an exception is thrown in EstablishTcpConnection.

This is needed because DNS resolution can fail when creating the TCP Connection.